### PR TITLE
Fix/card header

### DIFF
--- a/assets/styles/stylesheet.css
+++ b/assets/styles/stylesheet.css
@@ -117,7 +117,7 @@ main .container h1 {
 }
 
 .people-list .card-container {
-  height: 400px;
+  height: 422px;
   background: white;
   text-align: center;
   padding: 15px;

--- a/script/app.test.js
+++ b/script/app.test.js
@@ -2,7 +2,7 @@ import data from "../people/data.js";
 
 it("should not pass the characters limit", () => {
   const fields = data.filter((e) =>
-    Object.values(e).some((i) => i.length > 140)
+    Object.values(e).some((i) => i.length > 150)
   );
 
   expect(fields.length).toBe(0);


### PR DESCRIPTION
### Changes

- Quando fui adicionar minha descrição no card da página principal, que tinha 140 caracteres, percebi que ela estava quebrando e que não era pra ter esse comportamento tendo em vista que ela passava no teste. Com isso, fiz algumas modificações no css aumentando a altura do card para 422px e com isso obtive o resultado esperado.

- Como eu fiz um teste depois e vi que o card não mudava de comportamento até o limite de 150, achei válido fazer uma alteração propondo esse mesmo limite de 150. 

### Screenshots

#### Before:
![image](https://user-images.githubusercontent.com/38708454/96346775-899ef680-1095-11eb-8039-2a878180505a.png)

#### After:
![image](https://user-images.githubusercontent.com/38708454/96346792-9cb1c680-1095-11eb-8766-936329905fc8.png)

